### PR TITLE
feat: use jsdelivr cdn to prevent blocking

### DIFF
--- a/TRMNL/src/shared.liquid
+++ b/TRMNL/src/shared.liquid
@@ -18,9 +18,9 @@ Changelog:
 {% assign weather_icon_map = 'clear-night:mdi-weather-night,cloudy:mdi-weather-cloudy,fog:mdi-weather-fog,hail:mdi-weather-hail,lightning:mdi-weather-lightning,lightning-rainy:mdi-weather-lightning-rainy,partlycloudy:mdi-weather-partly-cloudy,pouring:mdi-weather-pouring,rainy:mdi-weather-rainy,snowy:mdi-weather-snowy,snowy-rainy:mdi-weather-snowy-rainy,sunny:mdi-weather-sunny,windy:mdi-weather-windy,windy-variant:mdi-weather-cloudy-arrow-right,exceptional:mdi-alert-circle,default:mdi-weather-cloudy' | split: ',' %}
 
 <!-- import Highcharts libraries -->
-<script src="https://code.highcharts.com/highcharts.js"></script>
-<script src="https://code.highcharts.com/highcharts-more.js"></script>
-<script src="https://code.highcharts.com/modules/pattern-fill.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/highcharts/highcharts.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/highcharts/highcharts-more.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/highcharts/modules/pattern-fill.js"></script>
 <style>
   @import url('https://cdn.jsdelivr.net/npm/@mdi/font/css/materialdesignicons.min.css');
   .sensor-value {


### PR DESCRIPTION
code.highcharts.com seems to have cloudflare in front, which tends to block traffic aggressively atm. This changes the chosen cdn to jsdelivr, which does not have this problem and is already used in this project